### PR TITLE
Fixed issue with weird errors when configuration is missing.

### DIFF
--- a/lib/simperium.rb
+++ b/lib/simperium.rb
@@ -12,6 +12,12 @@ UUID.state_file = false
 module Simperium
     class Auth
         def initialize(appname, api_key, host=nil,scheme='https')
+            if appname == nil
+              raise ArgumentError, "App name is required."
+            end
+            if api_key == nil
+              raise ArgumentError, "API key is required."
+            end
             if host == nil
                 host = ENV['SIMPERIUM_AUTHHOST'] || 'auth.simperium.com'
             end


### PR DESCRIPTION
This resolves the following error (typical for Heroku deploys):

```
undefined method `+' for nil:NilClass
/tmp/build_34k4k1xdyw6dh/vendor/bundle/ruby/2.0.0/bundler/gems/simperium-ruby-ccf6662007f0/lib/simperium.rb:87:in `authorize'
```
