### PR TITLE
Fix some typos in Bucket::delete and Bucket::changes

### DIFF
--- a/lib/simperium.rb
+++ b/lib/simperium.rb
@@ -289,7 +289,7 @@ module Simperium
 
         def delete(item, version=nil)
             ccid = self._gen_ccid()
-            url = "#{@appname}/#{@bucket}/i/{item}"
+            url = "#{@appname}/#{@bucket}/i/#{item}"
             
             if version
                 url += "/v/#{version}"

--- a/lib/simperium.rb
+++ b/lib/simperium.rb
@@ -303,7 +303,7 @@ module Simperium
         end
 
         def changes(options={})
-            defautls = {:cv=>nil, :timeout=>nil}
+            defaults = {:cv=>nil, :timeout=>nil}
             unless options.empty?
                 options = defaults.merge(options)
             else

--- a/lib/simperium.rb
+++ b/lib/simperium.rb
@@ -310,8 +310,8 @@ module Simperium
                 options = defaults
             end
 
-            cv = option[:cv]
-            timeout = option[:timeout]
+            cv = options[:cv]
+            timeout = options[:timeout]
 
             url = "#{@appname}/#{@bucket}/changes?clientid=#{@clientid}"
             unless cv.nil?


### PR DESCRIPTION
Actually I'm not sure whether the changes endpoint still exists (I get a 404) but these typographical fixes can't make things worse.

Have verified that Bucket::delete now works.
